### PR TITLE
docs(CONTRIBUTING): Conventional Commits 規約を明記し CI で強制 + ai-review 修正

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,19 @@ reviews:
   # レビュー全体の結果表示
   review_status: true
 
+  # リポジトリ全体に適用するレビュー指示
+  # (commit-lint.yml でも機械的に検証しているが、CodeRabbit にも注意喚起させる)
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        このリポジトリでは commit メッセージが CONTRIBUTING.md の規約に従っている必要があります。
+        許可される形式:
+          1. "Add <yourname> to contributors" (contributors.json 追加の初心者 PR)
+          2. Conventional Commits: "<type>(<scope>)?!?: <subject>"
+             type: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+        絵文字プレフィックス (📚, 🐛 等) は使用禁止。
+        もし違反する commit があれば、その旨を明示的に指摘してください。
+
   auto_review:
     enabled: true
     # Draft PR はレビューしない

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,32 @@
+<!--
+  ⚠️ PR を出す前に [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) を必ず読んでください。
+  特に以下の規約に違反すると CI で弾かれます:
+
+  - Commit Message: Conventional Commits 形式 (例: feat: xxx / fix(scope): yyy)
+  - 初心者の contributors.json 追加 PR は "Add <yourname> to contributors" 形式も可
+-->
+
+> [!IMPORTANT]
+> PR を出す前に [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) に目を通してください。
+> 特に **Commit Message の規約**（Conventional Commits）は CI で自動検証されます。
+
 ## 変更内容
 
 <!-- 何を変更したかを 1〜2 文で記入してください -->
 
 ## チェックリスト
 
+<!-- 該当するものにチェックを入れてください -->
+
+**contributors.json への追加 PR の場合:**
 - [ ] `data/contributors.json` に自分のエントリを 1 つだけ追加した
 - [ ] 他の人のエントリは変更・削除していない
 - [ ] `favoriteColor` は `#RRGGBB` 形式、`joinedAt` は `YYYY-MM-DD` 形式
+
+**コード・ドキュメント変更 PR の場合:**
+- [ ] Commit Message が Conventional Commits 形式に従っている
+- [ ] 関連する Issue 番号を記載している（あれば）
+- [ ] ローカルで `npm test` / `npm run build` が成功することを確認した
 
 ---
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -86,3 +86,12 @@ jobs:
               echo "::notice::Verdict=APPROVED → ai:approved 適用"
               ;;
           esac
+
+      # GITHUB_TOKEN で付与したラベルは pull_request:labeled イベントを発火しないため、
+      # merge-guard.yml が再実行されない。本ジョブ自身で CI を fail させて merge をブロックする。
+      - name: Fail on CHANGES_REQUESTED
+        if: steps.verdict.outputs.verdict == 'CHANGES_REQUESTED'
+        run: |
+          echo "::error::CodeRabbit のレビューで変更が要求されています (do-not-merge ラベル適用)。"
+          echo "        PR のレビューコメントを確認し、指摘事項を修正してから再 push してください。"
+          exit 1

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,10 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: Checkout PR
+      # /merge ref ではなく /head を checkout する。
+      # /merge は GitHub が生成する合成マージコミット (Merge xxx into yyy) を HEAD にするため、
+      # git log "$BASE_SHA"..HEAD の範囲にこのマージコミットが入ってしまい、
+      # Conventional Commits 正規表現に合致せず正常な PR でも CI が誤検知で fail する。
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: Validate commit messages

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,62 @@
+name: Commit Lint
+
+# PR 内の全 commit メッセージが CONTRIBUTING.md の規約に従っているか検証する。
+# 違反があれば exit 1 で CI を失敗させ、PR のマージをブロックする。
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+
+      - name: Validate commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # 許可される形式:
+          #   1. Add <name> to contributors   (contributors.json 追加の初心者 PR)
+          #   2. <type>(<scope>)?!?: <subject>  (Conventional Commits)
+          #      type: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+          REGEX='^((Add [A-Za-z0-9_-]+ to contributors)|((feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([A-Za-z0-9_/.-]+\))?!?:[[:space:]]+\S.+))$'
+
+          INVALID=""
+          while IFS= read -r line; do
+            SHA=$(printf '%s' "$line" | cut -d' ' -f1)
+            SUBJECT=$(printf '%s' "$line" | cut -d' ' -f2-)
+            if ! printf '%s' "$SUBJECT" | grep -qE "$REGEX"; then
+              INVALID="${INVALID}  - ${SHA:0:7}: ${SUBJECT}"$'\n'
+            fi
+          done < <(git log --format='%H %s' "$BASE_SHA"..HEAD)
+
+          if [ -n "$INVALID" ]; then
+            echo "::error::以下の commit メッセージが CONTRIBUTING.md の規約に従っていません:"
+            echo ""
+            printf '%s\n' "$INVALID"
+            echo "許可される形式:"
+            echo "  1. Add <yourname> to contributors   (contributors.json 追加の場合)"
+            echo "  2. <type>(<scope>)?!?: <subject>    (Conventional Commits)"
+            echo "     type: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            echo ""
+            echo "修正方法:"
+            echo "  - 最新 1 件: git commit --amend -m '新しいメッセージ' && git push --force-with-lease"
+            echo "  - 複数件:   git rebase -i origin/main で reword してから --force-with-lease"
+            echo ""
+            echo "詳細: CONTRIBUTING.md"
+            exit 1
+          fi
+
+          echo "✅ 全 commit メッセージが規約に準拠しています"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,103 +1,93 @@
 # Contributing to Git Training Ground
 
-Thank you for your interest in contributing! This project is designed for beginners to practice Git and Pull Requests.
+> [!IMPORTANT]
+> はじめての PR を練習したい方は [README](./README.md) または [/tutorial ページ](./app/tutorial/page.tsx) を参照してください。
+> このガイドは継続的な貢献やメンテナー向けです。
 
-## How to Contribute
+## Commit Message
 
-### Adding your entry to `data/contributors.json`
+[Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) 形式を採用します。**CI で検証されるため、規約違反があると merge できません**。
 
-1. **Fork** this repository
-2. Open `data/contributors.json` in your fork
-3. Click the **pencil icon** (Edit this file) to enter edit mode
-4. **Add your entry** to the end of the array:
+### 形式
 
-```json
-[
-  {
-    "name": "ketts",
-    "github": "t0k0shi",
-    "favoriteColor": "#E63946",
-    "favoriteEmoji": "🚀",
-    "message": "はじめてのOSS貢献！",
-    "joinedAt": "2026-04-24"
-  },
-  {
-    "name": "Your Name",
-    "github": "your-github-handle",
-    "favoriteColor": "#FF5E5B",
-    "favoriteEmoji": "🦊",
-    "message": "Nice to meet you!",
-    "joinedAt": "2026-04-24"
-  }
-]
+```
+<type>(<scope>)?: <subject>
 ```
 
-5. Choose **"Create a new branch for this commit and start a pull request"**
-6. Click **"Propose changes"** to commit
-7. Go to the **original repository** (`t0k0shi/git-training-ground`) and click **"Compare & pull request"**
-8. Click **"Create pull request"**
+### `<type>` 一覧
 
-### Required Fields
+| type | 意味 |
+|---|---|
+| `feat` | 新機能の追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメントのみの変更 |
+| `style` | コードスタイル（機能に影響しない）|
+| `refactor` | リファクタリング |
+| `perf` | パフォーマンス改善 |
+| `test` | テストの追加・修正 |
+| `build` | ビルドシステムや依存の変更 |
+| `ci` | CI 設定の変更 |
+| `chore` | 雑事（上記に該当しないもの）|
+| `revert` | コミットの取り消し |
 
-| Field | Description | Example |
-|-------|-------------|---------|
-| `name` | Display name | `"ketts"` |
-| `github` | GitHub handle (or full URL) | `"t0k0shi"` |
-| `favoriteColor` | Card border color (`#RRGGBB` hex) | `"#E63946"` |
-| `favoriteEmoji` | A single emoji character | `"🚀"` |
-| `message` | Short introduction | `"Nice to meet you!"` |
-| `joinedAt` | Date you submit the PR (`YYYY-MM-DD`) | `"2026-04-24"` |
+破壊的変更は `!` を付与: `refactor!: remove legacy EmojiCard`
 
-### Rules
+### 例
 
-- Add your entry at **the end of the array**
-- Do **not** delete or modify other people's entries
-- Each PR should add **exactly one entry**
-- Don't forget the **comma** after the previous entry's closing `}`
-- `favoriteColor` must match `#RRGGBB` (6 hex characters)
-- `favoriteEmoji` must be a single grapheme (1 character); emoji sequences like `👨‍👩‍👧` count as one
+良い例:
+- `feat: add floating bubbles to hero`
+- `fix(ContributorCard): prevent overflow on small screens`
+- `docs: update README.ja.md`
+- `ci: add commit-lint workflow`
 
-### CI Checks
+悪い例（CI で弾かれます）:
+- `added new feature` — prefix なし
+- `feat add feature` — コロンなし
+- `feat:` — subject が空
+- `📚 docs: xxx` — 絵文字プレフィックスは使わない
 
-Your PR will be automatically validated:
+### 特例: contributors.json のみの PR
 
-- JSON parses correctly
-- Required fields are present and non-empty
-- `favoriteColor` matches `#RRGGBB`
-- `joinedAt` matches `YYYY-MM-DD`
-- `github` handle is not a duplicate of an existing entry
-- `favoriteEmoji` is exactly 1 grapheme cluster
-- No existing entries are deleted or modified
-- Only 1 entry is added per PR
-- The site builds successfully
+チュートリアル参加者は次の簡易形式も許容されます:
 
-### AI Review
+```
+Add <yourname> to contributors
+```
 
-Pull requests that modify code (not just `contributors.json`) will receive an automated review from **CodeRabbit**. Reviews are posted in Japanese.
+例: `Add oginochihiro to contributors`
 
-- If the `do-not-merge` label is applied, please check and address the AI's feedback
-- Mention `@coderabbitai` in a comment to ask the bot for clarification or a re-review
-- Feel free to ask for help in the PR comments if you're unsure about anything — a maintainer will help
+## Branch
 
-### Local Validation
+```
+<type>/<short-desc>(-#<issue>)?
+```
 
-Before submitting, you can validate locally:
+- 例: `feat/floating-bubbles-#42`, `fix/avatar-overflow`
+- 特例（contributors PR）: `add-<yourname>`
+
+## Pull Request
+
+- 1 Issue に対して 1 PR を基本とする
+- PR タイトルも Commit Message と同じ形式を推奨
+- CI がすべて pass するまで修正
+- AI レビュー（CodeRabbit）の指摘を確認
+
+## AI Review
+
+[CodeRabbit](https://www.coderabbit.ai/) が PR ごとに日本語で自動レビューを投稿します。
+
+- `ai:approved` — 通過（マージ可）
+- `do-not-merge` + `ai:changes-requested` — 要修正
+- `@coderabbitai` にメンションで再レビュー依頼・質問が可能
+
+## ローカル事前チェック
 
 ```bash
-npx tsx scripts/validate-contributors.ts
+npx tsx scripts/validate-contributors.ts   # contributors.json 形式チェック
+npm test                                    # ユニットテスト
+npm run build                               # ビルド
 ```
-
-### Resolving Conflicts
-
-If your PR has conflicts:
-
-1. Open your fork's `data/contributors.json` on GitHub
-2. Edit the file to include both your entry and the latest entries from `main`
-3. Watch out for the trailing comma on the previous entry
-4. Commit the resolution to your branch
-
-If you're unsure, just comment on the PR — a maintainer will help.
 
 ## Code of Conduct
 
-Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+すべてのコントリビューターは [Code of Conduct](./CODE_OF_CONDUCT.md) を遵守してください。


### PR DESCRIPTION
## 変更内容

CONTRIBUTING.md に Commit Message 規約（Conventional Commits、絵文字プレフィックス禁止）を明記し、CI で自動検証するようにしました。あわせて既知の merge-guard 問題（post-verdict の CHANGES_REQUESTED 時に CI が止まらない）も修正しています。

## 主な変更

### CONTRIBUTING.md 刷新
- first-contributions-ja の構成を参考にしつつ、簡潔な内容に
- Commit Message: Conventional Commits 形式を規約として採用（絵文字プレフィックスは禁止）
  - type: feat / fix / docs / style / refactor / perf / test / build / ci / chore / revert
  - 良い例・悪い例・特例（Add <yourname> to contributors）を列挙
- Branch / Pull Request / AI Review / Code of Conduct の各セクション
- ローカル事前チェック手順

### Commit Lint の自動検証 (`.github/workflows/commit-lint.yml`)
- PR 内の全 commit メッセージを正規表現で検証
- 違反があれば exit 1 で CI fail（ラベル付与イベントに依存しない）
- 修正方法（git commit --amend / git rebase -i）も error log に表示

### Pull Request テンプレート更新
- 冒頭に `> [!IMPORTANT]` で CONTRIBUTING.md への誘導を追加
- チェックリストを「contributors.json 追加 PR」と「コード・ドキュメント PR」の 2 グループに分けた

### CodeRabbit 設定更新 (`.coderabbit.yaml`)
- `reviews.path_instructions` に「commit メッセージ規約違反を指摘するよう」指示を追加（二重安全）

### ai-review.yml の post-verdict 修正
- 既知の問題: GITHUB_TOKEN で付与したラベルは `pull_request:labeled` イベントを発火しないため、merge-guard.yml が再実行されず do-not-merge ラベル付きで pass のままになる
- 対応: post-verdict ジョブ自身が `verdict == CHANGES_REQUESTED` で `exit 1` するステップを追加、ラベルイベントに依存せず直接 CI を fail させる
- merge-guard.yml は手動ラベル付与時の保険として温存

## チェックリスト

- [x] Commit Message が Conventional Commits 形式に従っている (`docs:`, `fix:`)
- [x] YAML 構文検証成功（8 ファイル全て）
- [x] 正規表現の自己テスト: 良い例 4 件 pass / 悪い例 4 件 fail
- [x] ユニットテスト 104 件パス
- [x] ローカルで `npm run build` 成功

## 関連

- 参考: https://github.com/first-contributions-ja/first-contributions-ja.github.io/blob/main/docs/CONTRIBUTING.md
- 既知問題の詳細: [issue 化検討中] merge-guard + GITHUB_TOKEN のトリガー制約

## 想定される動作

1. 本 PR マージ後、以降の全 PR で `commit-lint` ワークフローが走る
2. Conventional Commits 違反があると CI fail → merge ブロック
3. CodeRabbit も path_instructions により同じ観点で指摘する（二重チェック）
4. `CHANGES_REQUESTED` verdict 時は post-verdict ジョブ自身が fail → merge-guard に依存せず merge ブロック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コミットメッセージの自動検証ワークフローを導入しました。指定の形式（貢献者エントリまたはコンベンショナルコミット）に準拠していないコミットを検出し、PRでエラーを報告します。
  * レビュー設定を拡張し、AI判定で「変更要求」が出た場合にCIが失敗してマージをブロックするようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->