### PR TITLE
fix(ai-review): request_changes_workflow 無効化 + verdict 判定 3 値化 (Issue #28)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,9 +10,15 @@ reviews:
   # 初心者向け OSS 練習場のため "chill" (穏やか) を選択
   profile: chill
 
-  # CodeRabbit が明確に問題を検出した際に GitHub の "Request changes" を使う
-  # → 我々の post-verdict ジョブで do-not-merge ラベル付与のトリガーになる
-  request_changes_workflow: true
+  # request_changes_workflow は無効化する。
+  # 有効時の仕様「全コメントが resolve された時点で自動 APPROVE」は人間レビュアーが
+  # @coderabbitai resolve や "Resolve conversation" ボタンを操作する前提のため、
+  # 修正 push だけでは APPROVE 状態に移行せず、ai-review.yml の post-verdict が
+  # 反応せずに do-not-merge ラベルが永久に残る問題が発生する。
+  # 通常の commented 形式に統一し、verdict 判定は post-verdict 側で inline_comments
+  # 数を見て行う (CHANGES_REQUESTED / APPROVED_WITH_WARNINGS / APPROVED の 3 値)。
+  # 詳細: Issue #28
+  request_changes_workflow: false
 
   # PR トップにサマリーを投稿
   high_level_summary: true

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -39,20 +39,32 @@ jobs:
         run: |
           set -euo pipefail
 
-          # inline comment 数を取得（Phase 2 で使う準備）
+          # inline comment 数を取得
           INLINE=$(gh api \
             "repos/${REPO}/pulls/${PR}/reviews/${REVIEW_ID}/comments" \
             --jq 'length' 2>/dev/null || echo "0")
           echo "inline_count=$INLINE" >> "$GITHUB_OUTPUT"
           echo "::notice::CodeRabbit review: state=$REVIEW_STATE inline_comments=$INLINE"
 
-          # Phase 1: 2 値判定
+          # 3 値判定 (Issue #28 対応):
+          # request_changes_workflow を無効化したため CodeRabbit は通常 commented を submit する。
+          # changes_requested は明示的に出されたケース、それ以外は inline_comments 数で判断する。
+          # 閾値: critical / 🔴 / "Potential issue" など重要指摘の検出は CodeRabbit の表記に依存
+          # するため、ここではシンプルに「inline_comments があれば warnings」とする。
+          # 将来的に inline_comments 本文を解析して severity 別判定に拡張可能。
           case "$REVIEW_STATE" in
             changes_requested)
               echo "verdict=CHANGES_REQUESTED" >> "$GITHUB_OUTPUT"
               ;;
-            approved|commented)
+            approved)
               echo "verdict=APPROVED" >> "$GITHUB_OUTPUT"
+              ;;
+            commented)
+              if [ "$INLINE" -gt 0 ]; then
+                echo "verdict=APPROVED_WITH_WARNINGS" >> "$GITHUB_OUTPUT"
+              else
+                echo "verdict=APPROVED" >> "$GITHUB_OUTPUT"
+              fi
               ;;
             *)
               echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
@@ -80,6 +92,10 @@ jobs:
             CHANGES_REQUESTED)
               gh pr edit "$PR" --repo "$REPO" --add-label "do-not-merge,ai:changes-requested"
               echo "::notice::Verdict=CHANGES_REQUESTED → do-not-merge + ai:changes-requested 適用"
+              ;;
+            APPROVED_WITH_WARNINGS)
+              gh pr edit "$PR" --repo "$REPO" --add-label "ai:approved-with-warnings"
+              echo "::notice::Verdict=APPROVED_WITH_WARNINGS → ai:approved-with-warnings 適用"
               ;;
             APPROVED)
               gh pr edit "$PR" --repo "$REPO" --add-label "ai:approved"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -39,35 +39,36 @@ jobs:
         run: |
           set -euo pipefail
 
-          # inline comment 数を取得。
-          # 取得失敗時は verdict 判定不能とみなして UNKNOWN に倒し、ラベル更新をスキップする。
-          # 失敗時に 0 にフォールバックすると、実際は指摘があるレビューを誤って APPROVED と
-          # 判定するリスクがある (silent failure)。
-          if ! INLINE=$(gh api \
-            "repos/${REPO}/pulls/${PR}/reviews/${REVIEW_ID}/comments" \
-            --jq 'length' 2>/dev/null); then
-            echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
-            echo "inline_count=0" >> "$GITHUB_OUTPUT"
-            echo "::warning::inline comment 数の取得に失敗。verdict 判定をスキップします"
-            exit 0
-          fi
-          echo "inline_count=$INLINE" >> "$GITHUB_OUTPUT"
-          echo "::notice::CodeRabbit review: state=$REVIEW_STATE inline_comments=$INLINE"
+          echo "::notice::CodeRabbit review: state=$REVIEW_STATE"
 
           # 3 値判定 (Issue #28 対応):
           # request_changes_workflow を無効化したため CodeRabbit は通常 commented を submit する。
           # changes_requested は明示的に出されたケース、それ以外は inline_comments 数で判断する。
-          # 閾値: critical / 🔴 / "Potential issue" など重要指摘の検出は CodeRabbit の表記に依存
-          # するため、ここではシンプルに「inline_comments があれば warnings」とする。
-          # 将来的に inline_comments 本文を解析して severity 別判定に拡張可能。
+          # inline_comments 数の取得は commented ブランチでのみ実行する。
+          # state 判定だけで決まる changes_requested / approved を巻き込んで UNKNOWN にしないため
+          # (取得失敗で merge ブロックが効かなくなるリスクを回避)。
           case "$REVIEW_STATE" in
             changes_requested)
               echo "verdict=CHANGES_REQUESTED" >> "$GITHUB_OUTPUT"
+              echo "inline_count=0" >> "$GITHUB_OUTPUT"
               ;;
             approved)
               echo "verdict=APPROVED" >> "$GITHUB_OUTPUT"
+              echo "inline_count=0" >> "$GITHUB_OUTPUT"
               ;;
             commented)
+              # commented のときだけ inline 件数で warnings/approved を分ける必要がある。
+              # 取得失敗時は UNKNOWN にして安全側に倒す。
+              if ! INLINE=$(gh api \
+                "repos/${REPO}/pulls/${PR}/reviews/${REVIEW_ID}/comments" \
+                --jq 'length' 2>/dev/null); then
+                echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
+                echo "inline_count=0" >> "$GITHUB_OUTPUT"
+                echo "::warning::inline comment 数の取得に失敗。verdict 判定をスキップします"
+                exit 0
+              fi
+              echo "inline_count=$INLINE" >> "$GITHUB_OUTPUT"
+              echo "::notice::inline_comments=$INLINE"
               if [ "$INLINE" -gt 0 ]; then
                 echo "verdict=APPROVED_WITH_WARNINGS" >> "$GITHUB_OUTPUT"
               else
@@ -76,6 +77,7 @@ jobs:
               ;;
             *)
               echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
+              echo "inline_count=0" >> "$GITHUB_OUTPUT"
               echo "::warning::未知の review state: $REVIEW_STATE"
               ;;
           esac

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -39,10 +39,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          # inline comment 数を取得
-          INLINE=$(gh api \
+          # inline comment 数を取得。
+          # 取得失敗時は verdict 判定不能とみなして UNKNOWN に倒し、ラベル更新をスキップする。
+          # 失敗時に 0 にフォールバックすると、実際は指摘があるレビューを誤って APPROVED と
+          # 判定するリスクがある (silent failure)。
+          if ! INLINE=$(gh api \
             "repos/${REPO}/pulls/${PR}/reviews/${REVIEW_ID}/comments" \
-            --jq 'length' 2>/dev/null || echo "0")
+            --jq 'length' 2>/dev/null); then
+            echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
+            echo "inline_count=0" >> "$GITHUB_OUTPUT"
+            echo "::warning::inline comment 数の取得に失敗。verdict 判定をスキップします"
+            exit 0
+          fi
           echo "inline_count=$INLINE" >> "$GITHUB_OUTPUT"
           echo "::notice::CodeRabbit review: state=$REVIEW_STATE inline_comments=$INLINE"
 

--- a/docs/adr/0009-disable-coderabbit-request-changes-workflow.md
+++ b/docs/adr/0009-disable-coderabbit-request-changes-workflow.md
@@ -1,0 +1,65 @@
+# ADR-0009: CodeRabbit の `request_changes_workflow` を無効化し verdict 判定を独自実装する
+
+- **Status**: Accepted
+- **Date**: 2026-04-25
+- **Refines**: [ADR-0008](./0008-coderabbit-over-copilot-for-reviews.md)
+- **Context**: PR #14 で発見した運用バグ（Issue #28）
+
+## Context
+
+PR #14 で以下の症状が発生:
+
+1. CodeRabbit が `CHANGES_REQUESTED` を出して `do-not-merge` ラベルが付く
+2. 指摘事項を修正してコミットを push
+3. CodeRabbit が「No actionable comments were generated in the recent review.」とコメントを投稿
+4. しかし `reviews` API には新しい review が submit されない（古い `CHANGES_REQUESTED` のまま）
+5. 結果: post-verdict ジョブが起動せず、ラベル更新されず、merge-guard が永久に fail
+
+### 根本原因
+
+`.coderabbit.yaml` で `request_changes_workflow: true` を有効化していた。CodeRabbit 公式ドキュメントによると、この機能は:
+
+> Once all comments are resolved, CodeRabbit automatically approves the PR.
+
+つまり「コメントが GitHub の "Resolve conversation" ボタン、または `@coderabbitai resolve` コマンドで明示的に dismiss された時点で、自動 APPROVE する」という設計。**人間レビュアーが操作する前提**の機能であり、修正 push だけでは APPROVE 状態に移行しない。
+
+我々の `ai-review.yml` post-verdict は `pull_request_review.submitted` イベントのみを起点にしているため、CodeRabbit が新しい review を submit しない限り反応せず、ラベルが古いまま固まる。
+
+## Decision
+
+**`request_changes_workflow: false`** に変更し、CodeRabbit のレビューを通常の `commented` 形式に統一する。verdict 判定は post-verdict 側で `inline_comments` 数を見て 3 値で行う:
+
+| Review State | Inline Comments | Verdict | 付与ラベル |
+|---|---|---|---|
+| `changes_requested` | 任意 | CHANGES_REQUESTED | `do-not-merge`, `ai:changes-requested` |
+| `approved` | 任意 | APPROVED | `ai:approved` |
+| `commented` | 0 | APPROVED | `ai:approved` |
+| `commented` | ≥ 1 | APPROVED_WITH_WARNINGS | `ai:approved-with-warnings` |
+| その他 | - | UNKNOWN | （ラベル変更なし） |
+
+## Consequences
+
+### Positive
+
+- **修正 push 後の自動的なラベル更新が機能する**: CodeRabbit は修正 push のたびに新しい `commented` review を submit するため、post-verdict が確実に起動する
+- ラベル付与イベント不発火問題（GITHUB_TOKEN 起因）への耐性向上
+- Phase 2 で予定していた 3 値判定が前倒しで実現
+
+### Negative
+
+- **CHANGES_REQUESTED の判定基準が変わる**: 以前は CodeRabbit 自身が `request_changes` を選んでいたが、今は `inline_comments ≥ 1` で判定するため、軽微な指摘でも `APPROVED_WITH_WARNINGS` 止まりになる
+  - 重大な問題のみ blocker にしたい場合は、CodeRabbit が明示的に `changes_requested` を出す挙動（`profile: assertive` や critical 指摘の自動判定）に依存
+- **inline コメントが 1 件でも付くと warnings 扱い**になるため、`profile: chill` でも頻繁に `ai:approved-with-warnings` が付く可能性
+  - 運用 2 週間で実態を観察し、必要なら閾値（1 → 3 等）を調整
+
+### 観察メトリクス
+
+- 修正 push 後、ラベルが期待通りに更新されるか
+- `APPROVED_WITH_WARNINGS` の発生比率が許容範囲か
+- 真に止めるべき PR（重大バグ含み）が `CHANGES_REQUESTED` で止まるか
+
+## 関連
+
+- Issue: #28（本問題の記録）
+- ADR-0005: 段階展開（本変更で Phase 2 が前倒しに）
+- ADR-0008: CodeRabbit 採用


### PR DESCRIPTION
## 概要

Issue #28 への対応。CodeRabbit の \`request_changes_workflow\` を無効化し、verdict 判定を 3 値に拡張します。Issue #24 (Phase 2 への拡張) も同時実現します。

Closes #28
Closes #24

## 問題

PR #14 で発見:
1. CodeRabbit が \`CHANGES_REQUESTED\` を出して \`do-not-merge\` ラベルが付く
2. 指摘事項を修正してコミットを push
3. CodeRabbit が「No actionable comments were generated in the recent review.」とコメント
4. しかし \`reviews\` API には新しい review が submit されない（古い CHANGES_REQUESTED のまま）
5. 結果: post-verdict ジョブが起動せず、ラベル更新されず、merge-guard が永久に fail

## 根本原因

\`.coderabbit.yaml\` の \`request_changes_workflow: true\` は **人間レビュアーが \"Resolve conversation\" ボタンや \`@coderabbitai resolve\` コマンドを操作する前提**の機能。修正 push だけでは APPROVE 状態に移行しない。

我々の post-verdict は \`pull_request_review.submitted\` のみを起点にしているため、CodeRabbit が新しい review を submit しない限り反応しない。

## 変更

### \`.coderabbit.yaml\`
- \`request_changes_workflow: true\` → **false**
- 修正 push 毎に CodeRabbit は通常の \`commented\` review を submit するようになる
- post-verdict が確実に起動する

### \`.github/workflows/ai-review.yml\`
verdict 判定を 3 値に拡張:

| Review State | Inline Comments | Verdict | ラベル |
|---|---|---|---|
| \`changes_requested\` | 任意 | CHANGES_REQUESTED | \`do-not-merge\`, \`ai:changes-requested\` |
| \`approved\` | 任意 | APPROVED | \`ai:approved\` |
| \`commented\` | 0 | APPROVED | \`ai:approved\` |
| \`commented\` | ≥ 1 | APPROVED_WITH_WARNINGS | \`ai:approved-with-warnings\` |

### \`docs/adr/0009-disable-coderabbit-request-changes-workflow.md\`
設計判断・影響・観察メトリクスを記録。

## チェックリスト

- [x] Conventional Commits 準拠（\`fix:\`）
- [x] YAML 構文 OK
- [x] 104 件全テストパス
- [x] ADR 作成（影響と観察ポイントを明示）

## 副作用と観察ポイント

- inline コメントが 1 件でも付くと \`APPROVED_WITH_WARNINGS\` 扱いになる
- \`profile: chill\` でも頻繁に warnings が付く可能性あり
- 運用 2 週間で実態を観察し、必要なら閾値（1 → 3 等）を調整

## 関連

- Issue #28: 本問題の記録
- Issue #24: Phase 2 拡張（本 PR で同時実現）
- ADR-0008: CodeRabbit 採用
- 公式 Docs: https://docs.coderabbit.ai/changelog/request-changes-workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * コードレビューのフィードバック方法をインラインコメント中心に変更し、従来の「直接の変更要求」フローを無効化
  * レビュー判定を「警告付き承認」「承認」「変更要求」の3段階で扱うように更新し、該当ラベルの適用を改善
  * インラインコメント集計が取得できない場合は安全に処理し、誤ったラベル適用を防止するよう対応
<!-- end of auto-generated comment: release notes by coderabbit.ai -->